### PR TITLE
GRAPHIQL-27-Fix-Header-z-index-and-Menu-width

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -1,6 +1,7 @@
 .header {
   position: sticky;
   top: 0;
+  z-index: 10;
   display: flex;
   align-items: center;
   justify-content: end;


### PR DESCRIPTION
# Description

 - fixed Menu width
 - fixed Header z-index

## Screenshot
![Screenshot_6](https://github.com/BazhenovYN/graphiql-app/assets/108691372/2a58a766-228c-4111-a658-a58af2841890)
![Screenshot_7](https://github.com/BazhenovYN/graphiql-app/assets/108691372/45b4586a-2079-4ef2-a232-8d6b9e7e093c)


## Reference

[GRAPHIQL-27](https://bazhenovyn.atlassian.net/browse/GRAPHIQL-27)

## Checklist

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- I have chosen appropriate labels
- I have added request reviewers


[GRAPHIQL-27]: https://bazhenovyn.atlassian.net/browse/GRAPHIQL-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ